### PR TITLE
convert the unit of depth image depending on depth image encoding.

### DIFF
--- a/include/realtime_urdf_filter/urdf_filter.h
+++ b/include/realtime_urdf_filter/urdf_filter.h
@@ -133,6 +133,7 @@ class RealtimeURDFFilter
     double near_plane_;
     double depth_distance_threshold_;
     double filter_replace_value_;
+    double unit_convert_value_;
 
     // neccesary for glutInit()..
     int argc_;

--- a/include/shaders/urdf_filter.frag
+++ b/include/shaders/urdf_filter.frag
@@ -11,6 +11,8 @@ uniform float z_far;
 
 uniform float max_diff;
 
+uniform float unit_convert_value;
+
 float to_linear_depth (float d)
 {
   return (z_near * z_far / (z_near - z_far)) / (d - z_far / (z_far - z_near));
@@ -20,7 +22,7 @@ void main(void)
 {
   // first color attachment: sensor depth image
   float sensor_depth = texelFetch (depth_texture, int(gl_FragCoord.y)*width + int(gl_FragCoord.x)).x;
-  sensor_depth = sensor_depth / 1000.0;   //Fix to get the depth in the right unit
+  sensor_depth = sensor_depth / unit_convert_value;   //Fix to get the depth in the right unit
   gl_FragData[0] = vec4 (sensor_depth, sensor_depth, sensor_depth, 1.0);
 
   // second color attachment: opengl depth image

--- a/src/urdf_filter.cpp
+++ b/src/urdf_filter.cpp
@@ -258,6 +258,11 @@ void RealtimeURDFFilter::filter_callback
     ROS_ERROR("cv_bridge Exception: %s", e.what());
     return;
   }
+  if (ros_depth_image->encoding == sensor_msgs::image_encodings::TYPE_16UC1) {
+    unit_convert_value_ = 1000.0;
+  } else {
+    unit_convert_value_ = 1.0;
+  }
 
   // Convert the depth image into a char buffer
   cv::Mat1f depth_image = orig_depth_img->image;
@@ -599,6 +604,7 @@ void RealtimeURDFFilter::render (const double* camera_projection_matrix)
   shader.SetUniformVal1f (std::string("z_near"), near_plane_);
   shader.SetUniformVal1f (std::string("max_diff"), float(depth_distance_threshold_));
   shader.SetUniformVal1f (std::string("replace_value"), float(filter_replace_value_));
+  shader.SetUniformVal1f (std::string("unit_convert_value"), float(unit_convert_value_));
   glBindTexture (GL_TEXTURE_BUFFER, depth_texture_);
 
   // render every renderable / urdf model


### PR DESCRIPTION
If encoding is TYPE_16UC1, the depth image is published from OpenNI node and the unit is millimeter.
otherwise, the unit is meter.