### PR TITLE
Adapt package to support ROS Melodic and some other improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,12 +47,13 @@ include_directories(SYSTEM ${ASSIMP_INCLUDE_DIRS})
 link_directories(${catkin_LIBRARY_DIRS} ${ASSIMP_LIBRARY_DIRS})
 
 set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake/)
-find_package(OpenNI)
+find_package(PkgConfig)
+pkg_check_modules(PC_LIBOPENNI REQUIRED libopenni)
 find_package(OpenCV REQUIRED)
 find_package(OpenGL)
 find_library(freeglut_LIBRARY glut /usr/lib)
 
-include_directories(${OPENGL_INCLUDE_DIR})
+include_directories(${OPENGL_INCLUDE_DIR} ${PC_LIBOPENNI_INCLUDE_DIRS})
 
 find_path( freeglut_INCLUDE_DIR GL/freeglut.h
   /usr/include/GL
@@ -82,7 +83,7 @@ target_link_libraries (urdf_filter
   ${ASSIMP_LIBRARIES})
 
 add_executable (urdf_filtered_tracker src/urdf_filtered_tracker.cpp)
-target_link_libraries (urdf_filtered_tracker urdf_filter OpenNI ${catkin_LIBRARIES})
+target_link_libraries (urdf_filtered_tracker urdf_filter ${PC_LIBOPENNI_LIBRARIES} ${catkin_LIBRARIES})
 
 add_executable (realtime_urdf_filter src/realtime_urdf_filter.cpp)
 target_link_libraries (realtime_urdf_filter urdf_filter ${catkin_LIBRARIES})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,7 +39,7 @@ catkin_package(
 #  DEPEND
   # CATKIN_DEPENDS
   INCLUDE_DIRS include
-  # LIBRARIES urdf_filter shadowwrapper
+  LIBRARIES urdf_filter
   )
 
 include_directories(include ${catkin_INCLUDE_DIRS})
@@ -110,4 +110,5 @@ endforeach(dir)
 install(FILES include/SamplesConfig.xml
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/include)
 
-# TODO install: include/GL3/gl3.h?
+install(DIRECTORY include/GL3
+  DESTINATION ${CATKIN_GLOBAL_INCLUDE_DESTINATION})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,7 +42,7 @@ catkin_package(
   # LIBRARIES urdf_filter shadowwrapper
   )
 
-include_directories(${catkin_INCLUDE_DIR} include)
+include_directories(include ${catkin_INCLUDE_DIRS})
 include_directories(SYSTEM ${ASSIMP_INCLUDE_DIRS})
 link_directories(${catkin_LIBRARY_DIRS} ${ASSIMP_LIBRARY_DIRS})
 
@@ -52,7 +52,7 @@ find_package(OpenCV REQUIRED)
 find_package(OpenGL)
 find_library(freeglut_LIBRARY glut /usr/lib)
 
-include_directories(${OPENGL_INCLUDE_DIR} ${catkin_INCLUDE_DIR})
+include_directories(${OPENGL_INCLUDE_DIR})
 
 find_path( freeglut_INCLUDE_DIR GL/freeglut.h
   /usr/include/GL

--- a/include/realtime_urdf_filter/realtime_urdf_filter_nodelet.h
+++ b/include/realtime_urdf_filter/realtime_urdf_filter_nodelet.h
@@ -45,6 +45,6 @@ namespace realtime_urdf_filter
     std::vector<std::string> args_;
     unsigned int argc_;
     char** argv_;
-    boost::shared_ptr<realtime_urdf_filter::RealtimeURDFFilter> filter_;
+    std::shared_ptr<realtime_urdf_filter::RealtimeURDFFilter> filter_;
   };
 }

--- a/include/realtime_urdf_filter/renderable.h
+++ b/include/realtime_urdf_filter/renderable.h
@@ -35,6 +35,7 @@
 #include <tf/tf.h>
 // this is necessary for diamondback. for more recent ROS versions, use:
 // #include <urdf_interface/color.h>
+#define ParseError std::runtime_error
 #include <urdf_model/color.h>
 
 #if defined(ASSIMP_UNIFIED_HEADER_NAMES)

--- a/include/realtime_urdf_filter/urdf_filter.h
+++ b/include/realtime_urdf_filter/urdf_filter.h
@@ -69,7 +69,7 @@ class RealtimeURDFFilter
 
     // does virtual rendering and filtering based on depth buffer and opengl proj. matrix
     void filter (
-        unsigned char* buffer, double* glTf, int width, int height);
+        unsigned char* buffer, double* glTf, int width, int height, ros::Time timestamp = ros::Time());
 
     // copy cv::Mat1f to char buffer
     unsigned char* bufferFromDepthImage (cv::Mat1f depth_image);
@@ -86,7 +86,7 @@ class RealtimeURDFFilter
     // compute Projection matrix from CameraInfo message
     void getProjectionMatrix (const sensor_msgs::CameraInfo::ConstPtr& current_caminfo, double* glTf);
 
-    void render (const double* camera_projection_matrix);
+    void render (const double* camera_projection_matrix, ros::Time timestamp = ros::Time());
 
     GLfloat* getMaskedDepth()
       {return masked_depth_;}

--- a/include/realtime_urdf_filter/urdf_renderer.h
+++ b/include/realtime_urdf_filter/urdf_renderer.h
@@ -50,7 +50,7 @@ class URDFRenderer
   protected:
     void initURDFModel ();
     void loadURDFModel (urdf::Model &descr);
-    void process_link (boost::shared_ptr<urdf::Link> link);
+    void process_link (std::shared_ptr<urdf::Link> link);
     void update_link_transforms ();
 
     // urdf model stuff
@@ -62,7 +62,7 @@ class URDFRenderer
     std::string fixed_frame_;
    
     // rendering stuff 
-    std::vector<boost::shared_ptr<Renderable> > renderables_;
+    std::vector<std::shared_ptr<Renderable> > renderables_;
     tf::TransformListener &tf_;
 };
 

--- a/include/realtime_urdf_filter/urdf_renderer.h
+++ b/include/realtime_urdf_filter/urdf_renderer.h
@@ -45,13 +45,13 @@ class URDFRenderer
 { 
   public:
     URDFRenderer (std::string model_description, std::string tf_prefix, std::string cam_frame, std::string fixed_frame, tf::TransformListener &tf);
-    void render ();
+    void render(ros::Time timestamp = ros::Time());
 
   protected:
     void initURDFModel ();
     void loadURDFModel (urdf::Model &descr);
     void process_link (std::shared_ptr<urdf::Link> link);
-    void update_link_transforms ();
+    void update_link_transforms(ros::Time timestamp = ros::Time());
 
     // urdf model stuff
     std::string model_description_;

--- a/package.xml
+++ b/package.xml
@@ -28,6 +28,7 @@
   <run_depend>libglew-dev</run_depend>
   <build_depend>glut</build_depend>
   <build_depend>assimp</build_depend>
+  <build_depend>libopenni-dev</build_depend>
 
   <export>
     <nodelet plugin="${prefix}/plugins/nodelet_plugins.xml" />

--- a/package.xml
+++ b/package.xml
@@ -26,6 +26,8 @@
   <run_depend>image_transport</run_depend>
   <build_depend>libglew-dev</build_depend>
   <run_depend>libglew-dev</run_depend>
+  <build_depend>glut</build_depend>
+  <build_depend>assimp</build_depend>
 
   <export>
     <nodelet plugin="${prefix}/plugins/nodelet_plugins.xml" />

--- a/src/realtime_urdf_filter_nodelet.cpp
+++ b/src/realtime_urdf_filter_nodelet.cpp
@@ -32,7 +32,7 @@
 #include <pluginlib/class_list_macros.h>
 
 // watch the capitalization carefully
-PLUGINLIB_DECLARE_CLASS(realtime_urdf_filter, RealtimeURDFFilterNodelet, realtime_urdf_filter::RealtimeURDFFilterNodelet, nodelet::Nodelet);
+PLUGINLIB_EXPORT_CLASS(realtime_urdf_filter::RealtimeURDFFilterNodelet, nodelet::Nodelet);
 
 namespace realtime_urdf_filter
 {

--- a/src/urdf_filter.cpp
+++ b/src/urdf_filter.cpp
@@ -227,12 +227,12 @@ void RealtimeURDFFilter::filter (
       sum += *it;
     }
 
-    std::cout << "Average framerate: " 
+    ROS_DEBUG_STREAM("Average framerate: "
       << std::setprecision(3) << double(count)/double(now - last) << " Hz " 
       << " (min: "<< min
       << ", max: " << max 
       << ", avg: " << sum / timings.size()
-      << " ms)" << std::endl;
+      << " ms)");
     count = 0;
     last = now;
     timings.clear();

--- a/src/urdf_filter.cpp
+++ b/src/urdf_filter.cpp
@@ -178,7 +178,7 @@ double RealtimeURDFFilter::getTime ()
 }
 
 void RealtimeURDFFilter::filter (
-    unsigned char* buffer, double* projection_matrix, int width, int height)
+    unsigned char* buffer, double* projection_matrix, int width, int height, ros::Time timestamp)
 {
   static std::vector<double> timings;
   double begin = getTime();
@@ -207,7 +207,7 @@ void RealtimeURDFFilter::filter (
   textureBufferFromDepthBuffer(buffer, size_in_bytes);
 
   // render everything
-  this->render(projection_matrix);
+  this->render(projection_matrix, timestamp);
 
   // Timing
   static unsigned count = 0;
@@ -246,7 +246,6 @@ void RealtimeURDFFilter::filter_callback
 {
   // Debugging
   ROS_DEBUG_STREAM("Received image with camera info: "<<*camera_info);
-
   // convert to OpenCV cv::Mat
   cv_bridge::CvImageConstPtr orig_depth_img;
   cv::Mat depth_image;
@@ -274,7 +273,7 @@ void RealtimeURDFFilter::filter_callback
   getProjectionMatrix (camera_info, projection_matrix);
 
   // Filter the image
-  this->filter(buffer, projection_matrix, depth_image.cols, depth_image.rows);
+  this->filter(buffer, projection_matrix, depth_image.cols, depth_image.rows, ros_depth_image->header.stamp);
 
   // publish processed depth image and image mask
   if (depth_pub_.getNumSubscribers() > 0)
@@ -295,7 +294,6 @@ void RealtimeURDFFilter::filter_callback
   if (mask_pub_.getNumSubscribers() > 0)
   {
     cv::Mat mask_image (height_, width_, CV_8UC1, mask_);
-
     cv_bridge::CvImage out_mask;
     out_mask.header = ros_depth_image->header;
     out_mask.encoding = sensor_msgs::image_encodings::MONO8;
@@ -475,7 +473,7 @@ void RealtimeURDFFilter::getProjectionMatrix (
   glTf[11]= -1;
 }
 
-void RealtimeURDFFilter::render (const double* camera_projection_matrix)
+void RealtimeURDFFilter::render (const double* camera_projection_matrix, ros::Time timestamp)
 {   
   static const GLenum buffers[] = {
     GL_COLOR_ATTACHMENT0,
@@ -494,7 +492,7 @@ void RealtimeURDFFilter::render (const double* camera_projection_matrix)
   // get transformation from camera to "fixed frame"
   tf::StampedTransform camera_transform;
   try {
-    tf_.lookupTransform (cam_frame_, fixed_frame_, ros::Time (), camera_transform);
+    tf_.lookupTransform (cam_frame_, fixed_frame_, timestamp, camera_transform);
     ROS_DEBUG_STREAM("Camera to world translation "<<
         cam_frame_<<" -> "<<fixed_frame_<<
         " ["<<
@@ -609,7 +607,7 @@ void RealtimeURDFFilter::render (const double* camera_projection_matrix)
   // render every renderable / urdf model
   std::vector<URDFRenderer*>::const_iterator r;
   for (r = renderers_.begin (); r != renderers_.end (); r++) {
-    (*r)->render ();
+    (*r)->render (timestamp);
   }
 
   // Disable shader

--- a/src/urdf_renderer.cpp
+++ b/src/urdf_renderer.cpp
@@ -134,7 +134,7 @@ namespace realtime_urdf_filter
 
   ////////////////////////////////////////////////////////////////////////////////
   /** \brief loops over all renderables and updates its transforms from TF */
-  void URDFRenderer::update_link_transforms ()
+  void URDFRenderer::update_link_transforms (ros::Time timestamp)
   {
     tf::StampedTransform t;
 
@@ -143,7 +143,7 @@ namespace realtime_urdf_filter
     {
       try
       {
-        tf_.lookupTransform (fixed_frame_, (*it)->name, ros::Time (), t);
+        tf_.lookupTransform (fixed_frame_, (*it)->name, timestamp, t);
       }
       catch (tf::TransformException ex)
       {
@@ -155,9 +155,9 @@ namespace realtime_urdf_filter
 
   ////////////////////////////////////////////////////////////////////////////////
   /** \brief loops over all renderables and renders them to canvas */
-  void URDFRenderer::render ()
+  void URDFRenderer::render (ros::Time timestamp)
   {
-    update_link_transforms ();
+    update_link_transforms (timestamp);
       
     std::vector<std::shared_ptr<Renderable> >::const_iterator it = renderables_.begin ();
     for (; it != renderables_.end (); it++)

--- a/src/urdf_renderer.cpp
+++ b/src/urdf_renderer.cpp
@@ -78,7 +78,7 @@ namespace realtime_urdf_filter
   void URDFRenderer::loadURDFModel
     (urdf::Model &model)
   {
-    typedef std::vector<boost::shared_ptr<urdf::Link> > V_Link;
+    typedef std::vector<std::shared_ptr<urdf::Link> > V_Link;
     V_Link links;
     model.getLinks(links);
 
@@ -91,30 +91,30 @@ namespace realtime_urdf_filter
 
   ////////////////////////////////////////////////////////////////////////////////
   /** \brief Processes a single URDF link, creates renderable for it */
-  void URDFRenderer::process_link (boost::shared_ptr<urdf::Link> link)
+  void URDFRenderer::process_link (std::shared_ptr<urdf::Link> link)
   {
     if (link->visual.get() == NULL || link->visual->geometry.get() == NULL)
       return;
 
-    boost::shared_ptr<Renderable> r;
+    std::shared_ptr<Renderable> r;
     if (link->visual->geometry->type == urdf::Geometry::BOX)
     {
-      boost::shared_ptr<urdf::Box> box = boost::dynamic_pointer_cast<urdf::Box> (link->visual->geometry);
+      std::shared_ptr<urdf::Box> box = std::dynamic_pointer_cast<urdf::Box> (link->visual->geometry);
       r.reset (new RenderableBox (box->dim.x, box->dim.y, box->dim.z));
     }
     else if (link->visual->geometry->type == urdf::Geometry::CYLINDER)
     {
-      boost::shared_ptr<urdf::Cylinder> cylinder = boost::dynamic_pointer_cast<urdf::Cylinder> (link->visual->geometry);
+      std::shared_ptr<urdf::Cylinder> cylinder = std::dynamic_pointer_cast<urdf::Cylinder> (link->visual->geometry);
       r.reset (new RenderableCylinder (cylinder->radius, cylinder->length));
     }
     else if (link->visual->geometry->type == urdf::Geometry::SPHERE)
     {
-      boost::shared_ptr<urdf::Sphere> sphere = boost::dynamic_pointer_cast<urdf::Sphere> (link->visual->geometry);
+      std::shared_ptr<urdf::Sphere> sphere = std::dynamic_pointer_cast<urdf::Sphere> (link->visual->geometry);
       r.reset (new RenderableSphere (sphere->radius));
     }
     else if (link->visual->geometry->type == urdf::Geometry::MESH)
     {
-      boost::shared_ptr<urdf::Mesh> mesh = boost::dynamic_pointer_cast<urdf::Mesh> (link->visual->geometry);
+      std::shared_ptr<urdf::Mesh> mesh = std::dynamic_pointer_cast<urdf::Mesh> (link->visual->geometry);
       std::string meshname (mesh->filename);
       RenderableMesh* rm = new RenderableMesh (meshname);
       rm->setScale (mesh->scale.x, mesh->scale.y, mesh->scale.z);
@@ -138,7 +138,7 @@ namespace realtime_urdf_filter
   {
     tf::StampedTransform t;
 
-    std::vector<boost::shared_ptr<Renderable> >::const_iterator it = renderables_.begin ();
+    std::vector<std::shared_ptr<Renderable> >::const_iterator it = renderables_.begin ();
     for (; it != renderables_.end (); it++)
     {
       try
@@ -159,7 +159,7 @@ namespace realtime_urdf_filter
   {
     update_link_transforms ();
       
-    std::vector<boost::shared_ptr<Renderable> >::const_iterator it = renderables_.begin ();
+    std::vector<std::shared_ptr<Renderable> >::const_iterator it = renderables_.begin ();
     for (; it != renderables_.end (); it++)
       (*it)->render ();
   }
@@ -169,8 +169,8 @@ namespace realtime_urdf_filter
 // REGEX BASED LINK / SEARCH OPERATIONS / TARGET FRAMES SETUP
 //    for (sop_it = search_operations_.begin (); sop_it != search_operations_.end (); sop_it++)
 //    {
-//      boost::smatch res;
-//      if (boost::regex_match(link->name, res, sop_it->re))
+//      std::smatch res;
+//      if (std::regex_match(link->name, res, sop_it->re))
 //      {
 //        if (!sop_it->pub_topic_re.empty ())
 //        {
@@ -184,9 +184,9 @@ namespace realtime_urdf_filter
 //        double r,p,y;
 //
 //        // handle special case of fixed links of drawers
-//        boost::shared_ptr<urdf::Collision> c;
-//        boost::regex re (".*_fixed_link");
-//        if (boost::regex_match(link->name, re))
+//        std::shared_ptr<urdf::Collision> c;
+//        std::regex re (".*_fixed_link");
+//        if (std::regex_match(link->name, re))
 //        {
 //          c = link->child_links[0]->collision;
 //


### PR DESCRIPTION
The package has been made compatible with ROS Melodic and should compile out of the box.
urdf_filter is now usable as a library by other ROS packages.
ros::Time() calls were replaced by the timestamp from the image message for more accurate transform lookup.