### PR TITLE
use all geometries per link

### DIFF
--- a/include/realtime_urdf_filter/renderable.h
+++ b/include/realtime_urdf_filter/renderable.h
@@ -105,7 +105,7 @@ struct RenderableCylinder : public Renderable
 // meshes are a tad more complicated than boxes and spheres
 struct RenderableMesh : public Renderable
 {
-  RenderableMesh (std::string meshname);
+  RenderableMesh (std::string meshname, float sx, float sy, float sz);
 
   virtual void render ();
   void setScale (float x, float y, float z);
@@ -134,12 +134,12 @@ private:
   void fromAssimpScene (const aiScene* scene);
   void initMesh (unsigned int i, const aiMesh* mesh, const aiNode* node);
 
+  std::string meshname_;
+
   std::vector<SubMesh> meshes;
   double scale_x;
   double scale_y;
   double scale_z;
-
-  std::string meshname_;
 };
 
 

--- a/include/realtime_urdf_filter/urdf_renderer.h
+++ b/include/realtime_urdf_filter/urdf_renderer.h
@@ -44,7 +44,7 @@ namespace realtime_urdf_filter
 class URDFRenderer
 {
   public:
-    URDFRenderer (std::string model_description, std::string tf_prefix, std::string cam_frame, std::string fixed_frame, tf::TransformListener &tf);
+    URDFRenderer (std::string model_description, std::string tf_prefix, std::string cam_frame, std::string fixed_frame, tf::TransformListener &tf, const std::string &geometry_type);
     void render(ros::Time timestamp = ros::Time());
 
   protected:
@@ -56,6 +56,7 @@ class URDFRenderer
     // urdf model stuff
     std::string model_description_;
     std::string tf_prefix_;
+    const std::string geometry_type;
 
     // camera stuff
     std::string camera_frame_;

--- a/include/realtime_urdf_filter/urdf_renderer.h
+++ b/include/realtime_urdf_filter/urdf_renderer.h
@@ -34,6 +34,7 @@
 #include <urdf/model.h>
 #include <tf/transform_listener.h>
 #include <realtime_urdf_filter/renderable.h>
+#include <unordered_set>
 
 // forward declares
 namespace ros {class NodeHandle;}
@@ -44,7 +45,9 @@ namespace realtime_urdf_filter
 class URDFRenderer
 {
   public:
-    URDFRenderer (std::string model_description, std::string tf_prefix, std::string cam_frame, std::string fixed_frame, tf::TransformListener &tf, const std::string &geometry_type, double scale);
+    URDFRenderer (std::string model_description, std::string tf_prefix,
+                  std::string cam_frame, std::string fixed_frame, tf::TransformListener &tf,
+                  const std::string &geometry_type, double scale, const std::unordered_set<std::string> &ignore);
     void render(ros::Time timestamp = ros::Time());
 
   protected:
@@ -58,6 +61,7 @@ class URDFRenderer
     std::string tf_prefix_;
     const std::string geometry_type;
     const double scale;
+    const std::unordered_set<std::string> ignore;
 
     // camera stuff
     std::string camera_frame_;

--- a/include/realtime_urdf_filter/urdf_renderer.h
+++ b/include/realtime_urdf_filter/urdf_renderer.h
@@ -44,7 +44,7 @@ namespace realtime_urdf_filter
 class URDFRenderer
 {
   public:
-    URDFRenderer (std::string model_description, std::string tf_prefix, std::string cam_frame, std::string fixed_frame, tf::TransformListener &tf, const std::string &geometry_type);
+    URDFRenderer (std::string model_description, std::string tf_prefix, std::string cam_frame, std::string fixed_frame, tf::TransformListener &tf, const std::string &geometry_type, double scale);
     void render(ros::Time timestamp = ros::Time());
 
   protected:
@@ -57,6 +57,7 @@ class URDFRenderer
     std::string model_description_;
     std::string tf_prefix_;
     const std::string geometry_type;
+    const double scale;
 
     // camera stuff
     std::string camera_frame_;

--- a/launch/filter_parameters.yaml
+++ b/launch/filter_parameters.yaml
@@ -9,6 +9,7 @@ models:
   tf_prefix: "/EXAMPLE"
   geometry_type: "visual" # "visual" or "collision"
   scale: 1.0
+  ignore: []
 # how far in front of the robot model is still deleted? (e.g. 0.05 = 5cm)
 depth_distance_threshold: 0.05
 show_gui: false

--- a/launch/filter_parameters.yaml
+++ b/launch/filter_parameters.yaml
@@ -7,6 +7,7 @@ camera_offset:
 models:
 - model: "robot_description"
   tf_prefix: "/EXAMPLE"
+  geometry_type: "visual" # "visual" or "collision"
 # how far in front of the robot model is still deleted? (e.g. 0.05 = 5cm)
 depth_distance_threshold: 0.05
 show_gui: false

--- a/launch/filter_parameters.yaml
+++ b/launch/filter_parameters.yaml
@@ -8,6 +8,7 @@ models:
 - model: "robot_description"
   tf_prefix: "/EXAMPLE"
   geometry_type: "visual" # "visual" or "collision"
+  scale: 1.0
 # how far in front of the robot model is still deleted? (e.g. 0.05 = 5cm)
 depth_distance_threshold: 0.05
 show_gui: false

--- a/package.xml
+++ b/package.xml
@@ -33,7 +33,7 @@
   <build_depend>libopenni-dev</build_depend>
 
   <export>
-    <nodelet plugin="${prefix}/plugins/nodelet_plugins.xml" />
+    <nodelet plugin="${prefix}/nodelet_plugins.xml" />
   </export>
 
 </package>

--- a/src/renderable.cpp
+++ b/src/renderable.cpp
@@ -303,8 +303,11 @@ namespace realtime_urdf_filter
     mutable resource_retriever::Retriever retriever_;
   };
 
-  RenderableMesh::RenderableMesh (std::string meshname) :
-    meshname_(meshname)
+  RenderableMesh::RenderableMesh (std::string meshname, float sx, float sy, float sz) :
+    meshname_(meshname),
+    scale_x(sx),
+    scale_y(sy),
+    scale_z(sz)
   {
     Assimp::Importer importer;
     importer.SetIOHandler(new ResourceIOSystem());

--- a/src/urdf_filter.cpp
+++ b/src/urdf_filter.cpp
@@ -161,9 +161,11 @@ void RealtimeURDFFilter::loadModels ()
         continue;
       }
 
+      const double scale = elem.hasMember("scale") ? double(elem["scale"]) : 1.0;
+
       // finally, set the model description so we can later parse it.
       ROS_INFO ("Loading URDF model: %s", description_param.c_str ());
-      renderers_.push_back (new URDFRenderer (content, tf_prefix, cam_frame_, fixed_frame_, tf_, elem["geometry_type"]));
+      renderers_.push_back (new URDFRenderer (content, tf_prefix, cam_frame_, fixed_frame_, tf_, elem["geometry_type"], scale));
     }
   }
   else

--- a/src/urdf_filter.cpp
+++ b/src/urdf_filter.cpp
@@ -134,8 +134,8 @@ void RealtimeURDFFilter::loadModels ()
       XmlRpc::XmlRpcValue elem = v[i];
       ROS_ASSERT (elem.getType()  == XmlRpc::XmlRpcValue::TypeStruct);
 
-      std::string description_param = elem["model"];
-      std::string tf_prefix = elem["tf_prefix"];
+      const std::string description_param = elem["model"];
+      const std::string tf_prefix = elem["tf_prefix"];
 
       // read URDF model
       std::string content;
@@ -163,7 +163,7 @@ void RealtimeURDFFilter::loadModels ()
 
       // finally, set the model description so we can later parse it.
       ROS_INFO ("Loading URDF model: %s", description_param.c_str ());
-      renderers_.push_back (new URDFRenderer (content, tf_prefix, cam_frame_, fixed_frame_, tf_));
+      renderers_.push_back (new URDFRenderer (content, tf_prefix, cam_frame_, fixed_frame_, tf_, elem["geometry_type"]));
     }
   }
   else

--- a/src/urdf_renderer.cpp
+++ b/src/urdf_renderer.cpp
@@ -47,11 +47,13 @@ namespace realtime_urdf_filter
                               std::string fixed_frame,
                               tf::TransformListener &tf,
                               const std::string &geometry_type,
-                              double scale)
+                              double scale,
+                              const std::unordered_set<std::string> &ignore)
     : model_description_(model_description)
     , tf_prefix_(tf_prefix)
     , geometry_type(geometry_type)
     , scale(scale)
+    , ignore(ignore)
     , camera_frame_ (cam_frame)
     , fixed_frame_(fixed_frame)
     , tf_(tf)
@@ -100,6 +102,9 @@ namespace realtime_urdf_filter
     std::vector<urdf::Pose> origins;
     std::vector<urdf::GeometryConstSharedPtr> geometries;
     std::vector<urdf::MaterialConstSharedPtr> materials;
+
+    // skip links that are not to be used for mask
+    if (ignore.count(link->name)) { return; }
 
     if (geometry_type.empty() || geometry_type == "visual")
     {

--- a/src/urdf_renderer.cpp
+++ b/src/urdf_renderer.cpp
@@ -46,10 +46,12 @@ namespace realtime_urdf_filter
                               std::string cam_frame,
                               std::string fixed_frame,
                               tf::TransformListener &tf,
-                              const std::string &geometry_type)
+                              const std::string &geometry_type,
+                              double scale)
     : model_description_(model_description)
     , tf_prefix_(tf_prefix)
     , geometry_type(geometry_type)
+    , scale(scale)
     , camera_frame_ (cam_frame)
     , fixed_frame_(fixed_frame)
     , tf_(tf)
@@ -132,22 +134,22 @@ namespace realtime_urdf_filter
       if (geometry->type == urdf::Geometry::BOX)
       {
         const urdf::BoxConstSharedPtr box = std::dynamic_pointer_cast<const urdf::Box> (geometry);
-        r = std::make_shared<RenderableBox>(box->dim.x, box->dim.y, box->dim.z);
+        r = std::make_shared<RenderableBox>(scale * box->dim.x, scale * box->dim.y, scale * box->dim.z);
       }
       else if (geometry->type == urdf::Geometry::CYLINDER)
       {
         const urdf::CylinderConstSharedPtr cylinder = std::dynamic_pointer_cast<const urdf::Cylinder> (geometry);
-        r = std::make_shared<RenderableCylinder>(cylinder->radius, cylinder->length);
+        r = std::make_shared<RenderableCylinder>(scale * cylinder->radius, scale * cylinder->length);
       }
       else if (geometry->type == urdf::Geometry::SPHERE)
       {
         const urdf::SphereConstSharedPtr sphere = std::dynamic_pointer_cast<const urdf::Sphere> (geometry);
-        r = std::make_shared<RenderableSphere>(sphere->radius);
+        r = std::make_shared<RenderableSphere>(scale * sphere->radius);
       }
       else if (geometry->type == urdf::Geometry::MESH)
       {
         const urdf::MeshConstSharedPtr mesh = std::dynamic_pointer_cast<const urdf::Mesh> (geometry);
-        r = std::make_shared<RenderableMesh>(mesh->filename, mesh->scale.x, mesh->scale.y, mesh->scale.z);
+        r = std::make_shared<RenderableMesh>(mesh->filename, scale * mesh->scale.x, scale * mesh->scale.y, scale * mesh->scale.z);
       }
       r->setLinkName (tf_prefix_+ "/" + link->name);
       const urdf::Vector3 position = origin.position;

--- a/src/urdf_renderer.cpp
+++ b/src/urdf_renderer.cpp
@@ -69,7 +69,7 @@ namespace realtime_urdf_filter
     urdf::Model model;
     if (!model.initString(model_description_))
     {
-      ROS_ERROR ("URDF failed Model parse");
+      ROS_FATAL ("URDF failed Model parse");
       return;
     }
 


### PR DESCRIPTION
This PR touches the geometry rendering and adds the following features:
1. allow rendering the `collision` geometries in place of the `visual` geometries (default: visual)
2. render all geometries in a link (a link can have multiple visual or collision geometries)
3. optional scale to change the size of the geometry dimensions (default: 1)
4. optionally ignore some links from the mask (default: none)

I added the new parameters to the example yaml file, but they can be omitted as they use default values when not set.